### PR TITLE
feat : /main, /auth, /user에 대해 라우팅하는 기능 구현

### DIFF
--- a/gateway/src/main/java/kr/flab/momukji/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/GatewayApplication.java
@@ -17,13 +17,23 @@ public class GatewayApplication {
 
 	@Bean
 	public RouteLocator routes(RouteLocatorBuilder builder) {
+
 		return builder.routes()
 			.route(p -> p
-				.path("/api")
-				.uri("http://localhost:8080/"))
+				.path("/main/**")
+				.filters(f -> f.rewritePath("/main", "/api"))
+				.uri("lb://main"))
 			.route(p -> p
-				.path("/apiRider")
-				.uri("http://localhost:8080/"))
+				.path("/auth/**")
+				.filters(f -> f.rewritePath("/auth/", "/api/"))
+				.uri("lb://auth"))
+			.route(p -> p
+				.path("/user/**")
+				.filters(f -> f.rewritePath("/user", "/api"))
+				.uri("lb://user")
+				
+			)
+				
 			.build();
 	}
 


### PR DESCRIPTION
* gateway 서비스로 main , auth , user 서비스의 api를 접근하려고 할때 자동으로 해당 서비스의 api로 접근하게 함. 
* 유레카 서버가 서비스를 찾도록 함. 
* 테스트 결과 (gateway 서비스 포트 번호 : 80 )
 --  예시1) http://localhost:80/auth/callUser 
  ![image](https://user-images.githubusercontent.com/68679529/179776164-7f609d0c-df88-4989-a1c7-4a704a607de6.png)
 -- 예시2) http://localhost:80/auth/validate
 ![image](https://user-images.githubusercontent.com/68679529/179776721-fce1cac0-1808-4e79-ac4f-810381b24564.png)
 -- 예시3) http://localhost:80/user/signup
![image](https://user-images.githubusercontent.com/68679529/179777020-87d732fb-8020-4a92-9c8e-f8f45213e460.png)

* main에 대한 테스트는 #11 완료 후 실시할 것임. 
* 테스트 중 찾은 에러 : http://localhost:80/auth/authenticate
 -- rewrite에 의해 /auth 를 /api로 바꾸게 해놓았는데 /authenticate의 /auth 부분도 변환해서 생기는 에러 였음 
 -- /authenticate를 /aut로 수정하고 테스트해보니 잘 작동하였음 
![image (1)](https://user-images.githubusercontent.com/68679529/179902149-6cafbbcb-4c1e-4e91-b0e5-76e773e89d52.png)
 -- 따라서 원래 auth서비스의 @PostMapping("/authenticate")부분을 @PostMapping("/login")으로 이름을 바꿔 gateway에서 호출하는 uri 주소를 바꾸도록 결정함. 즉 http://localhost:80/auth/login 로 호출하도록함. 
 -- http://localhost:80/auth/login 테스트 결과
![image](https://user-images.githubusercontent.com/68679529/179902953-be974cb6-e401-4a8c-97d0-329a63ee287a.png)
