### PR TITLE
[gateway] MongoDB API 호출 로그쌓기

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
         "gateway\\src\\main\\resources",
         "gateway\\src\\test"
     ],
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "automatic"
 }

--- a/gateway/bin/main/application.yml
+++ b/gateway/bin/main/application.yml
@@ -4,6 +4,30 @@ server:
 spring:
   application:
     name: gateway
+  cloud:
+    gateway:
+      routes:
+        - id: main
+          predicates:
+            - Path=/main/**
+          filters:
+            - RewritePath=/main, /api
+            - CustomAuthFilter
+          uri: lb://main
+        - id: auth
+          predicates:
+            - Path=/auth/**
+          filters:
+            - RewritePath=/auth/, /api/
+          uri: lb://auth
+        - id: user
+          predicates:
+            - Path=/user/**
+          filters:
+            - RewritePath=/user, /api
+          uri: lb://user
+      default-filters:
+        - LoggingFilter
 
 #스프링 유레카 클라이언트 구축
 eureka:
@@ -52,3 +76,4 @@ resilience4j:
     instances:
       circuit:
         baseConfig: default
+

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 dependencyManagement {

--- a/gateway/src/main/java/kr/flab/momukji/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/GatewayApplication.java
@@ -2,12 +2,7 @@ package kr.flab.momukji.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.gateway.route.RouteLocator;
-import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.context.annotation.Bean;
-
-import kr.flab.momukji.gateway.filter.CustomAuthFilter;
 
 @EnableEurekaClient
 @SpringBootApplication
@@ -15,28 +10,6 @@ public class GatewayApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(GatewayApplication.class, args);
-	}
-
-	@Bean
-	public RouteLocator routes(RouteLocatorBuilder builder, CustomAuthFilter customAuthFilter) {
-
-		return builder.routes()
-			.route(p -> p
-				.path("/main/**")
-				.filters(f -> f.rewritePath("/main", "/api")
-					.filter(customAuthFilter.apply(new CustomAuthFilter.Config()))
-				)
-				.uri("lb://main"))
-			.route(p -> p
-				.path("/auth/**")
-				.filters(f -> f.rewritePath("/auth/", "/api/"))
-				.uri("lb://auth"))
-			.route(p -> p
-				.path("/user/**")
-				.filters(f -> f.rewritePath("/user", "/api"))
-				.uri("lb://user")
-			)
-			.build();
 	}
 
 }

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/LoggingFilter.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/LoggingFilter.java
@@ -1,0 +1,64 @@
+package kr.flab.momukji.gateway.filter;
+
+import java.time.Instant;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+
+import kr.flab.momukji.gateway.filter.log.Log;
+import kr.flab.momukji.gateway.filter.log.LogService;
+import reactor.core.publisher.Mono;
+
+@Component
+public class LoggingFilter extends AbstractGatewayFilterFactory<LoggingFilter.Config> {
+
+    @Autowired
+    private LogService logService;
+
+    public LoggingFilter() {
+        super(Config.class);
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        GatewayFilter filter = new OrderedGatewayFilter((exchange,chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            ServerHttpResponse response = exchange.getResponse();
+            
+            String method = request.getMethodValue();
+            String uri = request.getURI().toString();
+            String parameters = request.getQueryParams().toString();
+            String ip = request.getRemoteAddress().getHostString();
+            Instant requestedTimestamp = Instant.now();
+            
+            return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+                Instant responsedTimestamp = Instant.now();
+                String status = String.valueOf(response.getStatusCode().value());
+                
+                Log log = Log.builder()
+                    .method(method)
+                    .uri(uri)
+                    .parameters(parameters)
+                    .ip(ip)
+                    .requestedTimestamp(requestedTimestamp)
+                    .responsedTimestamp(responsedTimestamp)
+                    .status(status)
+                    .build();
+                
+                logService.save(log);
+            }));
+        }, Ordered.LOWEST_PRECEDENCE);
+        
+        return filter;
+    }
+
+    public static class Config {
+
+    }
+}

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/LoggingFilter.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/LoggingFilter.java
@@ -32,7 +32,7 @@ public class LoggingFilter extends AbstractGatewayFilterFactory<LoggingFilter.Co
             ServerHttpResponse response = exchange.getResponse();
             
             String method = request.getMethodValue();
-            String uri = request.getURI().toString();
+            String uri = request.getURI().getPath();
             String parameters = request.getQueryParams().toString();
             String ip = request.getRemoteAddress().getHostString();
             Instant requestedTimestamp = Instant.now();

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/Log.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/Log.java
@@ -1,0 +1,22 @@
+package kr.flab.momukji.gateway.filter.log;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+
+import lombok.Builder;
+import lombok.ToString;
+
+@Builder
+public class Log {
+
+    @Id
+    public String id;
+    public String method;
+    public String uri;
+    public String parameters;
+    public String ip;
+    public Instant requestedTimestamp;
+    public Instant responsedTimestamp;
+    public String status;
+}

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/Log.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/Log.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import org.springframework.data.annotation.Id;
 
 import lombok.Builder;
-import lombok.ToString;
 
 @Builder
 public class Log {

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/LogRepository.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/LogRepository.java
@@ -1,0 +1,7 @@
+package kr.flab.momukji.gateway.filter.log;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface LogRepository extends MongoRepository<Log, String> {
+
+}

--- a/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/LogService.java
+++ b/gateway/src/main/java/kr/flab/momukji/gateway/filter/log/LogService.java
@@ -1,0 +1,22 @@
+package kr.flab.momukji.gateway.filter.log;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class LogService {
+    
+    private final LogRepository logRepository;
+
+    public void save(Log log) {
+        logRepository.save(log);
+    }
+
+    public List<Log> findAll() {
+        return logRepository.findAll();
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -4,6 +4,30 @@ server:
 spring:
   application:
     name: gateway
+  cloud:
+    gateway:
+      routes:
+        - id: main
+          predicates:
+            - Path=/main/**
+          filters:
+            - RewritePath=/main, /api
+            - CustomAuthFilter
+          uri: lb://main
+        - id: auth
+          predicates:
+            - Path=/auth/**
+          filters:
+            - RewritePath=/auth/, /api/
+          uri: lb://auth
+        - id: user
+          predicates:
+            - Path=/user/**
+          filters:
+            - RewritePath=/user, /api
+          uri: lb://user
+      default-filters:
+        - LoggingFilter
 
 #스프링 유레카 클라이언트 구축
 eureka:
@@ -52,3 +76,4 @@ resilience4j:
     instances:
       circuit:
         baseConfig: default
+


### PR DESCRIPTION
* 라우팅 방식 자바 코드 -> yml로 변경
  * 자바 코드 방식으로는 default-filters를 쓸 수 없다고 함 ㅠ

* MongoDB 관련 Log, LogRepository, LogService 구현
  * 기본적으로 로컬 27017 포트로 몽고디비 접속하게 돼있음!
  * 테스트 시 WSL에서 `docker run --name mongodb-container -v ~/data:/data/db -d -p 27017:27017 mongo` 명령어 등으로 몽고디비 먼저 켠 후 테스트해야 함
  * 테스트 시 설정 -> Java Debuggers -> Vm Args에 `java.net.preferIPv4Stack=true` 입력해야 아이피 정상적으로 입력됨

* 정상 동작 테스트 완료
  * main, auth, user 라우팅 잘 되는 것 확인했고
  * 로그도 잘 찍히는 것 확인함
```
{ 
  "_id" : ObjectId("62ec7ffcfc037c71734f3208"),
  "method" : "POST",
  "uri" : "/api/login",
  "parameters" : "{}",
  "ip" : "127.0.0.1",
  "requestedTimestamp" : ISODate("2022-08-05T02:27:08.007Z"),
  "responsedTimestamp" : ISODate("2022-08-05T02:27:08.009Z"),
  "status" : "200",
  "_class" : "kr.flab.momukji.gateway.filter.log.Log"
}
```